### PR TITLE
fix for 'No such namespace: nrepl.middleware.print'

### DIFF
--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -18,17 +18,22 @@
 
 (defn- whidbey-profile
   "Constructs a profile map for enabling the repl hooks."
-  [version options]
-  (->
-    `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
-      ;; :init is run once when the server starts
-      ;; :custom-init is run on session creation
-      :repl-options {:init (do (require 'whidbey.repl)
-                               (whidbey.repl/init! ~options))
-                     :custom-init (whidbey.repl/update-print-fn!)
-                     ;; :printer is nrepl 0.5.x only
-                     :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
-    (vary-meta assoc :repl true)))
+  [project]
+  (let [version (find-plugin-version project 'mvxcvi/whidbey)
+        options (:whidbey project)
+        {:keys [init custom-init]} (:repl-options project)]
+    (-> `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
+          ;; :init is run once when the server starts
+          ;; :custom-init is run on session creation
+          ;; ^:replace to workaround https://github.com/technomancy/leiningen/issues/878
+          :repl-options {:init ^:replace (do ~init
+                                             (require 'whidbey.repl)
+                                             (whidbey.repl/init! ~options))
+                         :custom-init ^:replace (do ~custom-init
+                                                    (whidbey.repl/update-print-fn!))
+                         ;; :printer is nrepl 0.5.x only
+                         :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
+        (vary-meta assoc :repl true))))
 
 
 (defn repl-pprint
@@ -38,7 +43,5 @@
   [project]
   (if (:whidbey/repl (:profiles project))
     project
-    (let [options (:whidbey project)
-          version (find-plugin-version project 'mvxcvi/whidbey)
-          profile (whidbey-profile version options)]
+    (let [profile (whidbey-profile project)]
       (project/add-profiles project {:whidbey/repl profile}))))

--- a/src/whidbey/plugin.clj
+++ b/src/whidbey/plugin.clj
@@ -21,9 +21,13 @@
   [version options]
   (->
     `{:dependencies [[mvxcvi/whidbey ~(or version "RELEASE")]]
-      :repl-options {:nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}
-                     :init (do (require 'whidbey.repl)
-                               (whidbey.repl/init! ~options))}}
+      ;; :init is run once when the server starts
+      ;; :custom-init is run on session creation
+      :repl-options {:init (do (require 'whidbey.repl)
+                               (whidbey.repl/init! ~options))
+                     :custom-init (whidbey.repl/update-print-fn!)
+                     ;; :printer is nrepl 0.5.x only
+                     :nrepl-context {:interactive-eval {:printer whidbey.repl/render-str}}}}
     (vary-meta assoc :repl true)))
 
 

--- a/src/whidbey/repl.clj
+++ b/src/whidbey/repl.clj
@@ -76,7 +76,8 @@
 (defn update-print-fn!
   "Updates nREPL's printing configuration to use Puget. nREPL 0.6.0+ only."
   []
-  (some-> (find-var 'nrepl.middleware.print/*print-fn*)
+  (some-> (find-ns 'nrepl.middleware.print)
+          (ns-resolve '*print-fn*)
           (var-set render)))
 
 

--- a/src/whidbey/repl.clj
+++ b/src/whidbey/repl.clj
@@ -51,6 +51,16 @@
     (assoc opts :print-handlers (print-handlers opts))))
 
 
+(defn render
+  "Renders the given value for display by pretty-printing it on the given writer
+  using Puget and the configured options."
+  ([value writer]
+   (render value writer nil))
+  ([value writer opts]
+   (binding [*out* writer]
+     (puget/pprint value (print-options opts)))))
+
+
 (defn render-str
   "Renders the given value to a display string by pretty-printing it using Puget
   and the configured options."
@@ -62,6 +72,13 @@
 
 
 ;; ## Initialization
+
+(defn update-print-fn!
+  "Updates nREPL's printing configuration to use Puget. nREPL 0.6.0+ only."
+  []
+  (some-> (find-var 'nrepl.middleware.print/*print-fn*)
+          (var-set render)))
+
 
 (defn update-options!
   "Updates the current rendering options by merging in the supplied map."


### PR DESCRIPTION
`(find-var 'nrepl.middleware.print/*print-fn*)` causes an Exception "No such namespace: nrepl.middleware.print" when the namespace is not found